### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         update: true
         install: >-
+          git
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-python-pip
           mingw-w64-x86_64-python-wheel

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -6,7 +6,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -51,10 +51,10 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Install pybind11
+    - name: Install requirements
       # This is required because --no-build-isolation disable dependences
       # installation
-      run: pip install pybind11
+      run: pip install pybind11 setuptools_scm
 
     - name: Build and install
       # --no-build-isolation is required because the vanilla setuptool does not

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ on:
       - published
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,11 @@
 requires = [
     "setuptools>=42",
     "pybind11>=2.10.0",
+    "setuptools_scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
 
 [tool.cibuildwheel]
 test-command = "python {project}/tests/test.py"

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@ import glob
 # Available at setup time due to pyproject.toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
+from setuptools_scm import get_version
 
-__version__ = "0.0.7"
+__version__ = get_version()
 
 # The main interface is through Pybind11Extension.
 # * You can add cxx_std=11/14/17, and then build_ext can be removed.


### PR DESCRIPTION
There was a problem with creating a release from the github web interface: the tag and the release are created at about the same moment. This could lead to the release build being cancelled, which would prevent the pypi artifacts from being uploaded since they would NOT be uploaded for the build of the tag.

This speculatively fixes the problem.

it also fixes the hard-coding of the version in a source file and switches to setuptools_scm instead