### PR TITLE
skip building pypy wheels, it seems to be broken

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -63,6 +63,7 @@ jobs:
         CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
         CIBW_ARCHS_LINUX: ${{ matrix.arch_linux }}
         CIBW_PRERELEASE_PYTHONS: true
+        CIBW_SKIP: pp*
 
     - name: Verify clean directory
       run: git diff --exit-code


### PR DESCRIPTION
related: https://github.com/pypa/cibuildwheel/issues/1983