### PR TITLE
Continue work towards supporting upload-artifact@v4

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,10 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: sdist
         path: dist/*.tar.gz
+        compression-level: 0
+        if-no-files-found: error
 
 
   build_wheels:
@@ -75,9 +78,12 @@ jobs:
       with:
         name: wheel-${{ matrix.os }}${{ matrix.artifact-extra }}
         path: wheelhouse/*.whl
+        compression-level: 0
+        if-no-files-found: error
 
 
   upload_all:
+    name: Upload release
     name: Upload if release
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
@@ -90,7 +96,6 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: artifact
         path: dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,13 +45,15 @@ jobs:
         include:
           - os: ubuntu-latest
             arch_linux: "aarch64"
-            extra: "- aarch64"
+            extra: " - aarch64"
             artifact-extra: "-aarch64"
           - os: ubuntu-latest
             arch_linux: "ppc64le"
+            extra: " - ppc64le"
             artifact-extra: "-ppc64le"
           - os: ubuntu-latest
             arch_linux: "s390x"
+            extra: " - s390x"
             artifact-extra: "-s390x"
     steps:
     - uses: actions/checkout@v4
@@ -96,6 +98,7 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         path: dist
+        merge-multiple: true
 
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,7 +84,6 @@ jobs:
 
   upload_all:
     name: Upload release
-    name: Upload if release
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
By not naming the artifacts to be downloaded, all artifacts are downloaded.

Compression level 0 is probably faster because wheels and so forth are compressed files.

We want to error if there are no files, that's certainly unexpected.